### PR TITLE
enhance the simd advisor 

### DIFF
--- a/src/advisor_pipelines.json
+++ b/src/advisor_pipelines.json
@@ -27,7 +27,8 @@
         { "__type__": "MainLoopAdvisor" },
         { "__type__": "PThreadAdvisor" },
         { "__type__": "TemplateLiteralValidateAdvisor" },
-        { "__type__": "ModularizeJSAdvisor" }
+        { "__type__": "ModularizeJSAdvisor" },
+        { "__type__": "SimdAdvisor" }
       ]
     },
     {

--- a/src/advisors/simd.ts
+++ b/src/advisors/simd.ts
@@ -8,14 +8,18 @@ import * as H from "../helper";
 import * as C from "../constants";
 import { registerAdvisorFactory } from "../advisor";
 import { Recipe } from "../recipe";
-import { ErrorAdviseRequest } from "../advise_requests/common_requests";
+import { ErrorAdviseRequest, PlainAdviseRequest } from "../advise_requests/common_requests";
 import { ConfigOptionChangeAction } from "../actions/config_option_change";
+import { ShowSuggestionAction, SuggestionExample } from "../actions/show_suggestion";
+import { ConfigEnvChangeAction } from "../actions/config_env_change";
 import {
   IAdviseRequest,
   IAdviseResult,
   IAdvisorFactory,
   IAdvisor,
   Project as IProject,
+  IArg,
+  IAction,
 } from "webinizer";
 
 class SimdAdvisorFactory implements IAdvisorFactory {
@@ -48,6 +52,103 @@ class SimdAdvisor implements IAdvisor {
     };
   }
 
+  private _getSuggestionExample(): SuggestionExample {
+    const before = `#ifdef _WIN32
+#include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif`;
+    const after = `#ifdef _WIN32
+#include <intrin.h>
+#else
+/* carefully comment or remove if it is not used */
+// #include <x86intrin.h>
+#endif`;
+    return new SuggestionExample(before, after);
+  }
+
+  private async _generateSimdStaticScanAdvise(
+    proj: IProject,
+    req: PlainAdviseRequest
+  ): Promise<IAdviseResult> {
+    const buildConfig = proj.config.getBuildConfigForTarget(proj.config.target);
+
+    const supportedInstructionSetsObj = {
+      sse: {
+        header: "#include <xmmintrin.h>",
+        flag: "-msse",
+      },
+      sse2: { header: "#include <emmintrin.h>", flag: "-msse2" },
+      sse3: { header: "#include <pmmintrin.h>", flag: "-msse3" },
+      ssse3: { header: "#include <tmmintrin.h>", flag: "-mssse3" },
+      sse4_1: { header: "#include <smmintrin.h>", flag: "-msse4.1" },
+      sse4_2: { header: "#include <nmmintrin.h>", flag: "-msse4.2" },
+      avx: { header: "#include <immintrin.h>", flag: "-mavx" },
+    };
+
+    let setKey: keyof typeof supportedInstructionSetsObj;
+    const actions: IAction[] = [];
+
+    for (setKey in supportedInstructionSetsObj) {
+      const matched = await H.findPatternInFiles(
+        supportedInstructionSetsObj[setKey].header,
+        proj.root,
+        [C.buildDir, C.dependencyDir]
+      );
+      if (
+        matched.length &&
+        !buildConfig.getEnv("cflags").includes(supportedInstructionSetsObj[setKey].flag)
+      ) {
+        // this instruction set is used in codebase, add
+        // corresponding flag into the compiler flags.
+        const addCflags: IArg[] = [
+          {
+            option: supportedInstructionSetsObj[setKey].flag,
+            value: null,
+            type: "replace",
+          },
+        ];
+
+        const action = new ConfigEnvChangeAction(
+          proj,
+          `Add corresponding compiler flag since \`${setKey}\` instruction set is used in the codebase`,
+          {
+            cflags: addCflags,
+          }
+        );
+
+        actions.push(action);
+      }
+    }
+
+    if (actions.length) {
+      return {
+        handled: true,
+        recipe: new Recipe(proj, "Recipe for SIMD intrinsic header issue", this, req, actions),
+      };
+    } else {
+      return {
+        handled: false,
+      };
+    }
+  }
+
+  private async _generateIntrinsicAdvise(
+    proj: IProject,
+    req: ErrorAdviseRequest
+  ): Promise<IAdviseResult> {
+    const action = new ShowSuggestionAction(
+      "error",
+      `Emscripten does \`not\` support including \`x86intrin.h\` directly, please check out your codebase and remove corresponding header files including statements if they are useless.\n As for using SIMD, please refer to [Using SIMD with WebAssembly](https://emscripten.org/docs/porting/simd.html#using-simd-with-webassembly)`,
+      this._getSuggestionExample(),
+      null
+    );
+    return {
+      handled: true,
+      recipe: new Recipe(proj, "Recipe for SIMD intrinsic header issue", this, req, action),
+    };
+  }
+
   /* eslint-disable @typescript-eslint/no-unused-vars */
   async advise(
     proj: IProject,
@@ -63,6 +164,19 @@ class SimdAdvisor implements IAdvisor {
       ) {
         return this._generateSimdAdvise(proj, errorReq);
       }
+
+      // check if the error is caused by x86intrinsic header file
+      const errRegexPattern =
+        /In file included from .+\/upstream\/lib\/clang\/((\d+\.\d+\.\d+)|\d+)\/include\/x86intrin.h/;
+
+      const matchResult = errorReq.error.match(errRegexPattern);
+      if (matchResult !== null) {
+        return this._generateIntrinsicAdvise(proj, errorReq);
+      }
+    }
+
+    if (req instanceof PlainAdviseRequest) {
+      return this._generateSimdStaticScanAdvise(proj, req);
     }
     return {
       handled: false,

--- a/src/advisors/simd.ts
+++ b/src/advisors/simd.ts
@@ -122,6 +122,19 @@ class SimdAdvisor implements IAdvisor {
     }
 
     if (actions.length) {
+      if (
+        !buildConfig.getEnv("cflags").includes("-msimd128") ||
+        !buildConfig.getEnv("ldflags").includes("-msimd128")
+      ) {
+        actions.push(
+          new ConfigOptionChangeAction(
+            proj,
+            "If you want to port `SIMD` code targeting WebAssembly, we should enable the `SIMD support` option.",
+            { needSimd: true }
+          )
+        );
+      }
+
       return {
         handled: true,
         recipe: new Recipe(proj, "Recipe for SIMD intrinsic header issue", this, req, actions),

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -271,7 +271,7 @@ export interface IPattern {
 }
 
 /**
- * Find specific petterns in files using `grep`
+ * Find specific patterns in files using `grep`
  * @param s Pattern for search
  * @param dir Base directory for search
  * @param excludeDirs Excluded directories for search

--- a/tests/advisor_tests.ts
+++ b/tests/advisor_tests.ts
@@ -354,6 +354,31 @@ describe("advisor", () => {
     expect((result.recipe as Recipe).actions[0].desc).to.include(actionDesc);
   });
 
+  it("SimdAdvisorTest2", async () => {
+    const errMsg =
+      "In file included from /home/.local/sdk/emsdk/upstream/lib/clang/16.0.0/include/x86intrin.h:13:\n";
+    const req = new ErrorAdviseRequest("cfg_args", errMsg, null, 0);
+    const actionDesc = `Emscripten does \`not\` support including \`x86intrin.h\` directly, please check out your codebase and remove corresponding header files including statements if they are useless.\n As for using SIMD, please refer to [Using SIMD with WebAssembly](https://emscripten.org/docs/porting/simd.html#using-simd-with-webassembly)`;
+    const advisorType = "SimdAdvisor";
+    const projRoot = path.join(TEST_ADVISOR_ASSETS_DIR, `${advisorType}_2`);
+    const result = await advise(advisorType, projRoot, req);
+
+    expect(result.handled).to.equal(true);
+    expect((result.recipe as Recipe).actions[0].desc).to.include(actionDesc);
+  });
+
+  it("SimdAdvisorTest3", async () => {
+    const req = new PlainAdviseRequest("pre-build", "");
+    const actionDescRegex =
+      /Add corresponding compiler flag since `(sse2|sse3|ssse3|sse4_1|sse4_2|avx)` instruction set is used in the codebase/;
+    const advisorType = "SimdAdvisor";
+    const projRoot = path.join(TEST_ADVISOR_ASSETS_DIR, `${advisorType}_2`);
+    const result = await advise(advisorType, projRoot, req);
+
+    expect(result.handled).to.equal(true);
+    expect((result.recipe as Recipe).actions[0].desc).to.match(actionDescRegex);
+  });
+
   it("StripAdvisorTest", async () => {
     const errMsg = "strip: file format not recognized\n";
     const req = new ErrorAdviseRequest("cfg_args", errMsg, null, 0);

--- a/tests/assets/advisors/SimdAdvisor_2/.webinizer/config.json
+++ b/tests/assets/advisors/SimdAdvisor_2/.webinizer/config.json
@@ -1,0 +1,22 @@
+{
+  "__type__": "ProjectConfig",
+  "name": "SimdAdvisorTest",
+  "desc": "Test config file for SimdAdvisor",
+  "version": "1.0.0",
+  "buildTargets": {
+    "static": {
+      "options": {
+        "needMainLoop": true,
+        "needPthread": false,
+        "needCppException": false,
+        "needSimd": true,
+        "needModularize": true
+      },
+      "envs": {
+        "cflags": "-msimd128",
+        "ldflags": "-msimd128 -sMODULARIZE=1"
+      }
+    }
+  },
+  "target": "static"
+}

--- a/tests/assets/advisors/SimdAdvisor_2/include/global.h
+++ b/tests/assets/advisors/SimdAdvisor_2/include/global.h
@@ -1,0 +1,7 @@
+// test for SEE instructions sets
+#include <emmintrin.h>
+#include <pmmintrin.h>
+#include <tmmintrin.h>
+#include <smmintrin.h>
+#include <nmmintrin.h>
+#include <immintrin.h>


### PR DESCRIPTION
to handle the scenarios
 - x86 intrinsic header file is included
 - compiler flags should be added when SSE intrinsic header files are included


to close #56 